### PR TITLE
fix-csv-dict

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ def config_courses(course_file="data/courses.csv"):
     reader = csv.DictReader(open(course_file))
     dict_list = []
     for line in reader:
-        dict_list.append(line)
+        dict_list.append(dict(line))
     return dict_list
 
 

--- a/ricktest.py
+++ b/ricktest.py
@@ -1,7 +1,0 @@
-profcourses = [
-    {'Prof': 'Dr. Hu', 'Course': 'CISC 101'}, 
-    {'Prof': 'Dr. Blostein', 'Course': 'CISC 102'}, 
-    {'Prof': 'Prof. Dove', 'Course': 'CISC 103'}
-]
-output = next(item for item in profcourses if item["Course"] == "CISC 101")
-print(output)

--- a/test_config.py
+++ b/test_config.py
@@ -1,0 +1,12 @@
+import config
+
+courses = config.config_courses()
+profs = config.config_profs()
+rooms = config.config_rooms()
+times = config.config_times()
+profdel = config.config_profcourselinks()
+print("Courses:",courses)
+print("Profs:",profs)
+print("Rooms:",rooms)
+print("Times:",times)
+print("Links:",profdel)


### PR DESCRIPTION
Bug reported where config.py was returning OrderedDict objects instead of plain dictionaries.  Reproduced issue on one computer and research found it likely due to difference in csv.dictreader method between python version 3.7 and 3.8.  Wrapped row in dict() function to recast into regular dict.  Also added a unit testing file.

Source: https://docs.python.org/3/library/csv.html